### PR TITLE
Add health check route

### DIFF
--- a/potts_spaces/app.py
+++ b/potts_spaces/app.py
@@ -1,0 +1,21 @@
+def app(environ, start_response):
+    if environ.get("PATH_INFO") == "/health":
+        body = b"OK"
+        start_response(
+            "200 OK",
+            [
+                ("Content-Type", "text/plain; charset=utf-8"),
+                ("Content-Length", str(len(body))),
+            ],
+        )
+        return [body]
+    
+    body = b"not found"
+    start_response(
+        "404 Not Found",
+        [
+            ("Content-Type", "text/plain; charset=utf-8"),
+            ("Content-Length", str(len(body))),
+        ],
+    )
+    return [body]

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,19 @@
+from potts_spaces.app import app
+
+
+def test_health_endpoint_returns_200():
+    environ = {
+        "PATH_INFO": "/health",
+        "REQUEST_METHOD": "GET",
+    }
+    
+    responses = {}
+    
+    def start_response(status, headers):
+        responses["status"] = status
+        responses["headers"] = headers
+    
+    body = app(environ, start_response)
+    
+    assert responses["status"] == "200 OK"
+    assert body == [b"OK"]


### PR DESCRIPTION
## Summary
- Adds /health endpoint for simple uptime checks
- Endpoint returns HTTP 200 OK with body "OK"
- Includes automated test for health endpoint functionality

## Acceptance Criteria Met
✅ endpoint exists at /health
✅ returns HTTP 200
✅ includes one basic automated test

## Test Coverage
- Test verifies health endpoint returns 200 OK status
- Test verifies health endpoint returns expected body

## Implementation
Following strict TDD approach:
1. Created failing test for /health endpoint
2. Implemented minimum code to pass test
3. Verified test passes and matches acceptance criteria

Closes #9