### PR TITLE
Add request logging for incoming paths

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,14 @@
+from wsgiref.simple_server import make_server
+
+
+def application(environ, start_response):
+    path = environ.get("PATH_INFO") or "/"
+    print(f"request path: {path}")
+
+    start_response("200 OK", [("Content-Type", "text/plain; charset=utf-8")])
+    return [b"OK\n"]
+
+
+if __name__ == "__main__":
+    with make_server("", 8000, application) as server:
+        server.serve_forever()

--- a/tests/test_request_logging.py
+++ b/tests/test_request_logging.py
@@ -1,0 +1,26 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+
+from app import application
+
+
+class RequestLoggingTests(unittest.TestCase):
+    def test_application_logs_incoming_path(self):
+        environ = {"PATH_INFO": "/debug/path"}
+        status_headers = []
+
+        def start_response(status, headers):
+            status_headers.append((status, headers))
+
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            body = b"".join(application(environ, start_response))
+
+        self.assertIn("/debug/path", stdout.getvalue())
+        self.assertEqual("200 OK", status_headers[0][0])
+        self.assertEqual(b"OK\n", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Log each incoming request path to stdout for easier debugging
- Add automated test verifying path is logged
- Maintain existing application behavior

## Test plan
- Run `python -m pytest tests/test_request_logging.py`
- Test passes, verifying request path logging functionality