### PR TITLE
docs: document local development startup (#61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# Potts Spaces
+
+## Local Development
+
+This app runs with Python's standard library. From the repository root, run the
+test suite first:
+
+```sh
+python3 -m unittest discover -s tests
+```
+
+Start the local web server:
+
+```sh
+python3 app.py
+```
+
+The app listens on `http://127.0.0.1:8000/`. In another terminal, verify the
+server response:
+
+```sh
+curl -i http://127.0.0.1:8000/
+```
+
+Expected response:
+
+```http
+HTTP/1.0 200 OK
+Content-Type: text/plain; charset=utf-8
+
+OK
+```
+
+Any path returns the same response body and logs the requested path in the server
+terminal:
+
+```sh
+curl http://127.0.0.1:8000/debug/path
+```
+
+Expected response body:
+
+```text
+OK
+```
+
+Expected server log:
+
+```text
+request path: /debug/path
+```
+
+Stop the server with `Ctrl-C`.

--- a/tests/test_readme_startup_docs.py
+++ b/tests/test_readme_startup_docs.py
@@ -1,0 +1,21 @@
+import unittest
+from pathlib import Path
+
+
+class ReadmeStartupDocsTests(unittest.TestCase):
+    def test_readme_documents_local_startup(self):
+        readme = Path("README.md")
+        self.assertTrue(readme.exists(), "README.md should document local startup")
+
+        content = readme.read_text(encoding="utf-8")
+
+        self.assertIn("python3 app.py", content)
+        self.assertIn("python3 -m unittest discover -s tests", content)
+        self.assertIn("curl -i http://127.0.0.1:8000/", content)
+        self.assertIn("HTTP/1.0 200 OK", content)
+        self.assertIn("OK", content)
+        self.assertIn("request path: /debug/path", content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #61

- Added `README.md` with full local development startup guide covering: install prerequisites, run test suite, start the local web server, and verify expected responses with curl examples.
- Added `tests/test_readme_startup_docs.py` validating that the README contains all required sections (startup command, test command, curl example, `HTTP/1.0 200 OK` response, and `request path:` log line).

## Test plan

- [x] `tests/test_readme_startup_docs.py` — validates all acceptance criteria sections are present in README
- [x] All tests pass: `python3 -m unittest discover -s tests`
- [x] README commands and paths verified against actual app structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)