### PR TITLE
feat: add /health endpoint (closes #60)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,15 @@
+import json
 from wsgiref.simple_server import make_server
 
 
 def application(environ, start_response):
     path = environ.get("PATH_INFO") or "/"
     print(f"request path: {path}")
+
+    if path == "/health":
+        body = json.dumps({"status": "ok"}).encode()
+        start_response("200 OK", [("Content-Type", "application/json")])
+        return [body]
 
     start_response("200 OK", [("Content-Type", "text/plain; charset=utf-8")])
     return [b"OK\n"]

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -1,0 +1,31 @@
+import json
+import unittest
+
+from app import application
+
+
+class HealthCheckTests(unittest.TestCase):
+    def _call(self, path):
+        environ = {"PATH_INFO": path}
+        status_headers = []
+
+        def start_response(status, headers):
+            status_headers.append((status, headers))
+
+        body = b"".join(application(environ, start_response))
+        return status_headers[0][0], status_headers[0][1], body
+
+    def test_health_returns_200(self):
+        status, _, _ = self._call("/health")
+        self.assertEqual("200 OK", status)
+
+    def test_health_returns_json_ok(self):
+        _, headers, body = self._call("/health")
+        content_types = [v for k, v in headers if k == "Content-Type"]
+        self.assertTrue(any("application/json" in ct for ct in content_types))
+        data = json.loads(body.decode())
+        self.assertEqual({"status": "ok"}, data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Added `GET /health` route to `app.py` that returns HTTP 200 with `Content-Type: application/json` and body `{"status": "ok"}`
- Added `tests/test_health_check.py` with two tests: status code and JSON body validation

## Test plan
- [x] `test_health_returns_200` — verifies `/health` responds with `200 OK`
- [x] `test_health_returns_json_ok` — verifies `Content-Type: application/json` and body `{"status": "ok"}`
- [x] Full suite: 4/4 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)