### PR TITLE
Issue #108: [STRESS] Idempotent create endpoint under concurrent retries

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,11 +1,18 @@
 import time
 import uuid
+import threading
+import hashlib
 from flask import Flask, request, jsonify, g
 
 app = Flask(__name__)
 START_TIME = time.time()
 VERSION = '1.0.0'
 BUILD = 'development'
+
+idempotency_store = {}
+idempotency_lock = threading.Lock()
+resources_store = {}
+resources_lock = threading.Lock()
 
 
 @app.before_request
@@ -53,3 +60,54 @@ def ready():
         'app': 'ok'
     }
     return jsonify(response), 200
+
+
+def compute_payload_hash(payload):
+    if payload is None:
+        return ''
+    return hashlib.sha256(str(payload).encode()).hexdigest()
+
+
+@app.route('/resources', methods=['POST'])
+def create_resource():
+    data = request.get_json() or {}
+    idempotency_key = request.headers.get('X-Idempotency-Key')
+    
+    if not idempotency_key:
+        resource_id = str(uuid.uuid4())
+        with resources_lock:
+            resources_store[resource_id] = {
+                'id': resource_id,
+                'name': data.get('name'),
+                'data': data.get('data')
+            }
+        return jsonify({'id': resource_id, 'name': data.get('name'), 'data': data.get('data')}), 201
+    
+    payload_hash = compute_payload_hash(data)
+    
+    with idempotency_lock:
+        existing = idempotency_store.get(idempotency_key)
+        
+        if existing:
+            if existing['payload_hash'] == payload_hash:
+                return jsonify(existing['response']), 201
+            else:
+                return jsonify({'error': 'Idempotency conflict: same key with different payload'}), 409
+        
+        resource_id = str(uuid.uuid4())
+        response_data = {
+            'id': resource_id,
+            'name': data.get('name'),
+            'data': data.get('data')
+        }
+        
+        idempotency_store[idempotency_key] = {
+            'payload_hash': payload_hash,
+            'response': response_data,
+            'resource_id': resource_id
+        }
+        
+        with resources_lock:
+            resources_store[resource_id] = response_data
+    
+    return jsonify(response_data), 201

--- a/tests/test_idempotent_create.py
+++ b/tests/test_idempotent_create.py
@@ -1,0 +1,97 @@
+import pytest
+import threading
+import time
+from app import app, idempotency_store
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+
+@pytest.fixture(autouse=True)
+def clear_store():
+    idempotency_store.clear()
+
+
+def test_idempotent_create_returns_same_result_for_same_key_and_payload(client):
+    payload = {'name': 'test-resource', 'data': 'value'}
+    headers = {'X-Idempotency-Key': 'key-123'}
+    
+    response1 = client.post('/resources', json=payload, headers=headers)
+    response2 = client.post('/resources', json=payload, headers=headers)
+    
+    assert response1.status_code == 201
+    assert response2.status_code == 201
+    assert response1.json['id'] == response2.json['id']
+    assert response1.json['name'] == response2.json['name']
+
+
+def test_idempotent_create_conflict_for_same_key_different_payload(client):
+    payload1 = {'name': 'test-resource', 'data': 'value1'}
+    payload2 = {'name': 'test-resource', 'data': 'value2'}
+    headers = {'X-Idempotency-Key': 'key-123'}
+    
+    response1 = client.post('/resources', json=payload1, headers=headers)
+    response2 = client.post('/resources', json=payload2, headers=headers)
+    
+    assert response1.status_code == 201
+    assert response2.status_code == 409
+    assert 'conflict' in response2.json['error'].lower()
+
+
+def test_create_without_idempotency_key_creates_new_resource(client):
+    payload = {'name': 'test-resource', 'data': 'value'}
+    
+    response1 = client.post('/resources', json=payload)
+    response2 = client.post('/resources', json=payload)
+    
+    assert response1.status_code == 201
+    assert response2.status_code == 201
+    assert response1.json['id'] != response2.json['id']
+
+
+def test_concurrent_requests_with_same_key_no_duplicates(client):
+    payload = {'name': 'concurrent-test', 'data': 'value'}
+    headers = {'X-Idempotency-Key': 'concurrent-key-123'}
+    results = []
+    errors = []
+    
+    def make_request():
+        with app.test_client() as thread_client:
+            with app.app_context():
+                try:
+                    response = thread_client.post('/resources', json=payload, headers=headers)
+                    results.append((response.status_code, response.json if response.json else {}))
+                except Exception as e:
+                    errors.append(str(e))
+    
+    threads = [threading.Thread(target=make_request) for _ in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    
+    assert len(errors) == 0
+    successful_results = [r for r in results if r[0] == 201]
+    assert len(successful_results) >= 1
+    
+    created_ids = [r[1]['id'] for r in successful_results]
+    assert len(set(created_ids)) == 1
+
+
+def test_idempotency_key_expiry(client):
+    payload = {'name': 'expiry-test', 'data': 'value'}
+    headers = {'X-Idempotency-Key': 'expiry-key-123'}
+    
+    response1 = client.post('/resources', json=payload, headers=headers)
+    assert response1.status_code == 201
+    original_id = response1.json['id']
+    
+    time.sleep(2)
+    
+    response2 = client.post('/resources', json=payload, headers=headers)
+    assert response2.status_code == 201
+    assert response2.json['id'] == original_id


### PR DESCRIPTION
What changed
- Completed issue #108: [STRESS] Idempotent create endpoint under concurrent retries.

Why
- Addresses issue #108 requirements.

How verified
- added idempotent POST /resources endpoint with X-Idempotency-Key header support; verified_by: pytest tests/ -v (exit 0)

Risks
- Low to moderate; follow-up review may request adjustments.

Closes #108