### PR TITLE
Issue #122: Health check: ready/live split with metadata contract

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,15 +1,36 @@
-from flask import Flask, request
+from flask import Flask, request, jsonify
 import logging
+import time
 
 app = Flask(__name__)
 logger = logging.getLogger('app')
+start_time = time.time()
+VERSION = '1.0.0'
+BUILD = 'local'
 
+def get_health_metadata():
+    uptime = time.time() - start_time
+    return {
+        'status': 'alive',
+        'uptime_seconds': uptime,
+        'version': VERSION,
+        'build': BUILD
+    }
 
 @app.before_request
 def log_request():
     logger.info(f'Request path: {request.path}')
 
-
 @app.route('/health')
 def health_check():
     return 'OK', 200
+
+@app.route('/live')
+def live_check():
+    return jsonify(get_health_metadata()), 200
+
+@app.route('/ready')
+def ready_check():
+    metadata = get_health_metadata()
+    metadata['status'] = 'ready'
+    return jsonify(metadata), 200

--- a/app.py
+++ b/app.py
@@ -8,6 +8,8 @@ start_time = time.time()
 VERSION = '1.0.0'
 BUILD = 'local'
 
+DEPENDENCIES_OK = True
+
 def get_health_metadata():
     uptime = time.time() - start_time
     return {
@@ -16,6 +18,9 @@ def get_health_metadata():
         'version': VERSION,
         'build': BUILD
     }
+
+def check_dependencies():
+    return DEPENDENCIES_OK
 
 @app.before_request
 def log_request():
@@ -32,5 +37,9 @@ def live_check():
 @app.route('/ready')
 def ready_check():
     metadata = get_health_metadata()
-    metadata['status'] = 'ready'
-    return jsonify(metadata), 200
+    if check_dependencies():
+        metadata['status'] = 'ready'
+        return jsonify(metadata), 200
+    else:
+        metadata['status'] = 'not_ready'
+        return jsonify(metadata), 503

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -30,3 +30,65 @@ def test_request_logging_logs_incoming_path(client):
     log_contents = log_stream.getvalue()
     assert '/health' in log_contents
     assert 'Request' in log_contents or 'request' in log_contents
+
+
+def test_live_endpoint_returns_json_with_required_fields(client):
+    response = client.get('/live')
+    assert response.status_code == 200
+    data = response.get_json()
+    assert 'status' in data
+    assert 'uptime_seconds' in data
+    assert 'version' in data
+    assert 'build' in data
+
+
+def test_live_endpoint_field_types(client):
+    response = client.get('/live')
+    data = response.get_json()
+    assert isinstance(data['status'], str)
+    assert isinstance(data['uptime_seconds'], (int, float))
+    assert isinstance(data['version'], str)
+    assert isinstance(data['build'], str)
+
+
+def test_live_endpoint_status_is_alive(client):
+    response = client.get('/live')
+    data = response.get_json()
+    assert data['status'] == 'alive'
+
+
+def test_live_endpoint_uptime_is_positive(client):
+    response = client.get('/live')
+    data = response.get_json()
+    assert data['uptime_seconds'] >= 0
+
+
+def test_ready_endpoint_returns_json_with_required_fields(client):
+    response = client.get('/ready')
+    assert response.status_code == 200
+    data = response.get_json()
+    assert 'status' in data
+    assert 'uptime_seconds' in data
+    assert 'version' in data
+    assert 'build' in data
+
+
+def test_ready_endpoint_field_types(client):
+    response = client.get('/ready')
+    data = response.get_json()
+    assert isinstance(data['status'], str)
+    assert isinstance(data['uptime_seconds'], (int, float))
+    assert isinstance(data['version'], str)
+    assert isinstance(data['build'], str)
+
+
+def test_ready_endpoint_status_when_dependencies_ok(client):
+    response = client.get('/ready')
+    data = response.get_json()
+    assert data['status'] in ['ready', 'not_ready']
+
+
+def test_health_endpoint_remains_compatible(client):
+    response = client.get('/health')
+    assert response.status_code == 200
+    assert response.data == b'OK'

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -88,6 +88,20 @@ def test_ready_endpoint_status_when_dependencies_ok(client):
     assert data['status'] in ['ready', 'not_ready']
 
 
+def test_ready_endpoint_returns_not_ready_when_dependencies_fail(client):
+    import app as app_module
+    original_deps_ok = app_module.DEPENDENCIES_OK
+    app_module.DEPENDENCIES_OK = False
+    
+    response = client.get('/ready')
+    
+    app_module.DEPENDENCIES_OK = original_deps_ok
+    
+    assert response.status_code == 503
+    data = response.get_json()
+    assert data['status'] == 'not_ready'
+
+
 def test_health_endpoint_remains_compatible(client):
     response = client.get('/health')
     assert response.status_code == 200


### PR DESCRIPTION
What changed
- Completed issue #122: Health check: ready/live split with metadata contract.

Why
- Addresses issue #122 requirements.

How verified
- Added /live and /ready endpoints with metadata contract (status, uptime_seconds, version, build) and contract tests; verified_by: pytest tests/ (exit 0)

Risks
- Low to moderate; follow-up review may request adjustments.

Closes #122